### PR TITLE
Make go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module main
+module github.com/alrevuelta/go-waku-light
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"main/contract"
 	"math/big"
 	"os"
 	"time"
+
+	"github.com/alrevuelta/go-waku-light/contract"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	libp2pprot "github.com/libp2p/go-libp2p/core/protocol"


### PR DESCRIPTION
* Make `go-waku-light` a go module.
* This will allow being imported by other external modules.