### PR TITLE
Dockerize + Github action

### DIFF
--- a/.github/workflows/push_master.yml
+++ b/.github/workflows/push_master.yml
@@ -1,0 +1,28 @@
+name: Push Image (master)
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - id: commit
+        uses: pr-mpt/actions-commit-hash@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: alrevuelta/go-waku-light:${{ steps.commit.outputs.short }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.20-alpine AS build
+
+WORKDIR /app
+
+COPY . .
+
+RUN apk add --update gcc g++
+RUN go mod download
+RUN go build -o /main
+
+FROM golang:1.20-alpine
+
+WORKDIR /
+
+COPY --from=build /main /main
+
+ENTRYPOINT ["/main"]


### PR DESCRIPTION
* Dockerize `go-waku-light`
* Add Github action to build and push later master docker image

Available at `alrevuelta/go-waku-light:{commit_id_first_7_numbers}`