### PR TITLE
Add delay to allow membership be indexed

### DIFF
--- a/main.go
+++ b/main.go
@@ -598,6 +598,10 @@ func Register(cfg *Config, privKey string, amount int, userMessageLimit uint32) 
 		filesNames = append(filesNames, fileName)
 	}
 
+	// We wait some time to ensure the root is in nwaku nodes
+	log.Info("Waiting for the root to be propagated to the network...")
+	time.Sleep(6 * time.Second)
+
 	return filesNames, nil
 }
 


### PR DESCRIPTION
* If a membership is registered and right after a message is sent, it can happen that `nwaku` nodes have not yet indexed the new membership.
* This PR fixes that by adding a sleep after registering the memberships.