### PR TITLE
Reset msgId when equal userMessageLimit

### DIFF
--- a/main.go
+++ b/main.go
@@ -449,6 +449,10 @@ func main() {
 
 						msgId++
 
+						if msgId == uint32(userMessageLimit) {
+							msgId = 0
+						}
+
 						log.Info("Message sent: ", messageToSend, " sleeping ", messageEverySecs, " seconds...")
 						time.Sleep(time.Duration(messageEverySecs) * time.Second)
 					}


### PR DESCRIPTION
* Fix of minor bug.
* In `send-messages-loop` the `msgId` increased forever.
* This PR fixes it by resetting it once it reaches the `userMessageLimit`.